### PR TITLE
Support 'optional' multiplicity

### DIFF
--- a/src/context/builder.rs
+++ b/src/context/builder.rs
@@ -69,7 +69,7 @@ pub(crate) struct ServiceBuilder
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct FieldBuilder
 {
-    pub(crate) repeated: bool,
+    pub(crate) multiplicity: Multiplicity,
     pub(crate) field_type: FieldTypeBuilder,
     pub(crate) name: String,
     pub(crate) number: u64,
@@ -445,7 +445,7 @@ impl FieldBuilder
         oneof: Option<OneofRef>,
     ) -> Result<MessageField, ParseError>
     {
-        let multiplicity = resolve_multiplicity(self.repeated, &self.field_type, &self.options);
+        let multiplicity = resolve_multiplicity(self.multiplicity, &self.field_type, &self.options);
         Ok(MessageField {
             name: self.name,
             number: self.number,
@@ -458,14 +458,14 @@ impl FieldBuilder
 }
 
 fn resolve_multiplicity(
-    repeated: bool,
+    proto_multiplicity: Multiplicity,
     field_type: &FieldTypeBuilder,
     options: &[ProtoOption],
 ) -> Multiplicity
 {
-    // If this isn't a repeated field, the multiplicity is always Single.
-    if !repeated {
-        return Multiplicity::Single;
+    // If this isn't a repeated field, the multiplicity follows the proto one (single or optional).
+    if proto_multiplicity != Multiplicity::Repeated {
+        return proto_multiplicity;
     }
 
     // Repeated field.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -284,7 +284,7 @@ pub struct MessageField
 }
 
 /// Defines the multiplicity of the field values.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Multiplicity
 {
     /// Field is not repeated.
@@ -295,6 +295,9 @@ pub enum Multiplicity
 
     /// Field is repeated by packing.
     RepeatedPacked,
+
+    /// Field is optional.
+    Optional,
 }
 
 /// Message `oneof` details.

--- a/src/proto.pest
+++ b/src/proto.pest
@@ -59,9 +59,11 @@ type_ = { "double" | "float" | "int32" | "int64" | "uint32" | "uint64"
     | "bool" | "string" | "bytes" | messageType | enumType }
 fieldNumber = { intLit }
 
+optional = { "optional" }
 repeated = { "repeated" }
-opt_repeated = { repeated? }
-field = { opt_repeated ~ type_ ~ fieldName ~ "=" ~ fieldNumber ~ ( "[" ~ fieldOptions ~ "]" )? ~ ";" }
+one_multiplicity = { repeated | optional }
+multiplicity = { one_multiplicity? }
+field = { multiplicity ~ type_ ~ fieldName ~ "=" ~ fieldNumber ~ ( "[" ~ fieldOptions ~ "]" )? ~ ";" }
 fieldOptions = { fieldOption ~ ( "," ~ fieldOption )* }
 fieldOption = { optionName ~ "=" ~ constant }
 

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -1,0 +1,51 @@
+#[test]
+fn parse()
+{
+    use protofish::context::{
+        Context, MessageField, MessageInfo, Multiplicity, Package, TypeParent, ValueType,
+    };
+
+    let context = Context::parse(&[r#"
+      syntax = "proto3";
+      message Message {
+          string s = 1;
+          repeated bytes b = 2;
+          optional int64 large = 3;
+          repeated sint32 signed = 4;
+          Message child = 10;
+      }
+    "#])
+    .unwrap();
+
+    let mut expected = Context::new();
+    let package = expected.insert_package(Package::new(None)).unwrap();
+    let mut message = MessageInfo::new("Message".to_string(), TypeParent::Package(package));
+
+    message
+        .add_field(MessageField::new("s".to_string(), 1, ValueType::String))
+        .unwrap();
+
+    let mut b_field = MessageField::new("b".to_string(), 2, ValueType::Bytes);
+    b_field.multiplicity = Multiplicity::Repeated;
+
+    let mut large_field = MessageField::new("large".to_string(), 3, ValueType::Int64);
+    large_field.multiplicity = Multiplicity::Optional;
+
+    let mut signed_field = MessageField::new("signed".to_string(), 4, ValueType::SInt32);
+    signed_field.multiplicity = Multiplicity::RepeatedPacked;
+
+    let child_field = MessageField::new(
+        "child".to_string(),
+        10,
+        ValueType::Message(message.self_ref),
+    );
+
+    message.add_field(b_field).unwrap();
+    message.add_field(large_field).unwrap();
+    message.add_field(signed_field).unwrap();
+    message.add_field(child_field).unwrap();
+
+    expected.insert_message(message).unwrap();
+
+    assert_eq!(expected, context);
+}


### PR DESCRIPTION
'optional' is now officially supported in proto3 syntax (which is what protofish parses).

This adds 'Optional' as a new variant of the 'Multiplicity' enum, which is a breaking change as that enum is an exhaustive enum.