### PR TITLE
Expose field iterator

### DIFF
--- a/src/context/api.rs
+++ b/src/context/api.rs
@@ -134,7 +134,8 @@ impl MessageInfo
     }
 
     /// Gets a oneof by a oneof reference.
-    pub fn get_oneof(&self, oneof: OneofRef) -> Option<&Oneof> {
+    pub fn get_oneof(&self, oneof: OneofRef) -> Option<&Oneof>
+    {
         self.oneofs.iter().find(|oo| oo.self_ref == oneof)
     }
 }

--- a/src/context/api.rs
+++ b/src/context/api.rs
@@ -113,6 +113,12 @@ impl TypeInfo
 
 impl MessageInfo
 {
+    /// Iterates all message fields.
+    pub fn iter_fields(&self) -> impl Iterator<Item = &MessageField>
+    {
+        self.fields.values()
+    }
+
     /// Get a field by its number.
     pub fn get_field(&self, number: u64) -> Option<&MessageField>
     {
@@ -125,6 +131,11 @@ impl MessageInfo
         self.fields_by_name
             .get(name)
             .and_then(|id| self.get_field(*id))
+    }
+
+    /// Gets a oneof by a oneof reference.
+    pub fn get_oneof(&self, oneof: OneofRef) -> Option<&Oneof> {
+        self.oneofs.iter().find(|oo| oo.self_ref == oneof)
     }
 }
 

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -1,6 +1,5 @@
 use protofish::context::{
-    Context, EnumField, EnumInfo, MessageField, MessageInfo, Oneof, Package, TypeParent,
-    ValueType,
+    Context, EnumField, EnumInfo, MessageField, MessageInfo, Oneof, Package, TypeParent, ValueType,
 };
 
 #[test]
@@ -107,26 +106,26 @@ fn iterate_fields()
     let mut fields = message.iter_fields();
 
     let immediate = fields.next().unwrap();
-    assert_eq!( immediate.name, "immediate" );
-    assert!( immediate.oneof.is_none() );
+    assert_eq!(immediate.name, "immediate");
+    assert!(immediate.oneof.is_none());
 
     let a1 = fields.next().unwrap();
-    assert_eq!( a1.name, "a1" );
-    assert!( a1.oneof.is_some() );
-    assert_eq!( message.get_oneof(a1.oneof.unwrap()).unwrap().name, "a" );
+    assert_eq!(a1.name, "a1");
+    assert!(a1.oneof.is_some());
+    assert_eq!(message.get_oneof(a1.oneof.unwrap()).unwrap().name, "a");
     let a2 = fields.next().unwrap();
-    assert_eq!( a2.name, "a2" );
-    assert!( a2.oneof.is_some() );
-    assert_eq!( message.get_oneof(a2.oneof.unwrap()).unwrap().name, "a" );
+    assert_eq!(a2.name, "a2");
+    assert!(a2.oneof.is_some());
+    assert_eq!(message.get_oneof(a2.oneof.unwrap()).unwrap().name, "a");
 
     let b1 = fields.next().unwrap();
-    assert_eq!( b1.name, "b1" );
-    assert!( b1.oneof.is_some() );
-    assert_eq!( message.get_oneof(b1.oneof.unwrap()).unwrap().name, "b" );
+    assert_eq!(b1.name, "b1");
+    assert!(b1.oneof.is_some());
+    assert_eq!(message.get_oneof(b1.oneof.unwrap()).unwrap().name, "b");
     let b2 = fields.next().unwrap();
-    assert!( b2.oneof.is_some() );
-    assert_eq!( message.get_oneof(b2.oneof.unwrap()).unwrap().name, "b" );
-    assert_eq!( b2.name, "b2" );
+    assert!(b2.oneof.is_some());
+    assert_eq!(message.get_oneof(b2.oneof.unwrap()).unwrap().name, "b");
+    assert_eq!(b2.name, "b2");
 
-    assert_eq!( fields.next(), None );
+    assert_eq!(fields.next(), None);
 }


### PR DESCRIPTION
Add `iter_fields` on `MessageInfo` struct. Also added `get_oneof` to make it easier to resolve the parent oneofs of said fields (made tests cleaner so figured that makes sense publicly as well. \o/).